### PR TITLE
Add peer deps and missing ajv formats

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,5 +41,9 @@
     "@types/object-hash": "^1.3.4",
     "prettier": "^2.2.1",
     "typescript": "^4.2.2"
+  },
+  "peerDependencies": {
+    "ajv": "^8.0.0",
+    "ajv-formats": "^2.0.0"
   }
 }

--- a/src/templates.ts
+++ b/src/templates.ts
@@ -4,12 +4,17 @@ export const decodersTemplate = `
 import Ajv, { ErrorObject } from 'ajv';
 import schema from './$SchemaName-schema.json';
 import * as types from './$SchemaName-models'
+import addFormats from "ajv-formats";
 
 // !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 // !!! AUTO GENERATED CODE, DON'T TOUCH !!!
 // !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 
 const ajv = new Ajv({ strict: false });
+
+// Adds more formats like date-time, int32, and int64.
+addFormats(ajv);
+
 ajv.addSchema(schema);
 
 function validateJson(json: any, schemaRef: string, definitionName: string): any {
@@ -33,7 +38,7 @@ function validateJson(json: any, schemaRef: string, definitionName: string): any
 }
 
 function errorsText(errors: ErrorObject[]): string {
-  return errors.map(error => \`\${error.dataPath}: \${error.message}\`).join('\\n')
+  return errors.map(error => \`\${error.instancePath}: \${error.message}\`).join('\\n')
 }
 
 // Decoders


### PR DESCRIPTION
Great library! Here are fixes for some snags I hit.

- Add `ajv` and `ajv-format` as `peerDepedencies`. They're needed to consume the generated files, so I thought that `peerDependencies` was another way to communicate that. The specific version of `ajv` matters, and `peerDependencies` seems like a good way to point that out.
- There was a breaking change in `ajv@8.0.0` which renamed `ErrorObject.dataPath` to `ErrorObject.instancePath`. The changelog can be found [here](https://github.com/ajv-validator/ajv/releases/tag/v8.0.0).
- I got `unknown format` warnings for `date-time`, `int32`, and `int64`. The `date-time` warning was solved by `ajv-format`, but the `int32` and `int64` warnings weren't. However, `int32` and `int64` are sitting in `master` (see [this](https://github.com/ajv-validator/ajv-formats/pull/22) PR), so they should be in their next release.