### PR TITLE
Fix: prevent warnings when importing decoder

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openapi-typescript-validator",
-  "version": "3.2.0",
+  "version": "3.2.1",
   "description": "Generate typescript with ajv validation based on openapi schemas",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/generate/generate-compile-decoders.ts
+++ b/src/generate/generate-compile-decoders.ts
@@ -56,8 +56,8 @@ import { $ModelImports } from './models';
 import jsonSchema from './schema.json';
 
 const ajv = new Ajv({ strict: false });
-ajv.compile(jsonSchema);
 $Formats
+ajv.compile(jsonSchema);
 
 // Decoders
 $Decoders

--- a/tests/src/__snapshots__/custom-schema.test.ts.snap
+++ b/tests/src/__snapshots__/custom-schema.test.ts.snap
@@ -11,6 +11,7 @@ import { Screen, ImageComponent, ListerComponent } from \\"./models\\";
 import jsonSchema from \\"./schema.json\\";
 
 const ajv = new Ajv({ strict: false });
+
 ajv.compile(jsonSchema);
 
 // Decoders

--- a/tests/src/__snapshots__/format-schema.test.ts.snap
+++ b/tests/src/__snapshots__/format-schema.test.ts.snap
@@ -11,8 +11,8 @@ import { User, Price } from \\"./models\\";
 import jsonSchema from \\"./schema.json\\";
 
 const ajv = new Ajv({ strict: false });
-ajv.compile(jsonSchema);
 addFormats(ajv, { mode: \\"fast\\", formats: [\\"date\\", \\"time\\"] });
+ajv.compile(jsonSchema);
 
 // Decoders
 export const UserDecoder: Decoder<User> = {
@@ -53,8 +53,8 @@ import { User, Price } from \\"./models\\";
 import jsonSchema from \\"./schema.json\\";
 
 const ajv = new Ajv({ strict: false });
-ajv.compile(jsonSchema);
 addFormats(ajv, undefined);
+ajv.compile(jsonSchema);
 
 // Decoders
 export const UserDecoder: Decoder<User> = {

--- a/tests/src/format-schema.test.ts
+++ b/tests/src/format-schema.test.ts
@@ -2,6 +2,7 @@ import path from "path";
 import fs from "fs";
 import { generate } from "openapi-typescript-validator";
 import Ajv from 'ajv';
+import spyOn = jest.spyOn;
 
 describe("format-schema - compile based", () => {
   const name = "format";
@@ -17,6 +18,12 @@ describe("format-schema - compile based", () => {
       directory: generatedDir,
       addFormats: true,
     });
+  });
+
+  test("should not generate warnings on import", async () => {
+    const consoleWarnSpy = spyOn(console, 'warn');
+    await import(path.join(generatedDir, 'decoders.ts'));
+    expect(consoleWarnSpy).not.toHaveBeenCalled();
   });
 
   test("files should match", () => {

--- a/tests/tsconfig.json
+++ b/tests/tsconfig.json
@@ -8,7 +8,8 @@
     "declaration": true,
     "sourceMap": true,
     "esModuleInterop": true,
-    "skipLibCheck": true
+    "skipLibCheck": true,
+    "resolveJsonModule": true
   },
   "include": ["src/**/*"],
   "exclude": ["node_modules", "tests"]


### PR DESCRIPTION
Currently, importing a decoder with format enabled causes warnings such as:
```
  console.warn
    unknown format "date" ignored in schema at path "#/definitions/User/properties/createdAt"

      at console.<anonymous> (node_modules/jest-mock/build/index.js:845:25)
      at unknownFormat (node_modules/ajv/lib/vocabularies/format/format.ts:84:23)
      at validateFormat (node_modules/ajv/lib/vocabularies/format/format.ts:75:9)
      at Object.code (node_modules/ajv/lib/vocabularies/format/format.ts:40:10)
```

This PR fixes that by flipping the order of `addFormats` and `ajv.compile`