### PR TITLE
Feature/esm output

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "openapi-typescript-validator",
-  "version": "3.2.0",
+  "version": "3.3.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openapi-typescript-validator",
-  "version": "3.2.0",
+  "version": "3.3.0",
   "description": "Generate typescript with ajv validation based on openapi schemas",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openapi-typescript-validator",
-  "version": "3.3.0-alpha",
+  "version": "3.2.0",
   "description": "Generate typescript with ajv validation based on openapi schemas",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openapi-typescript-validator",
-  "version": "3.2.0",
+  "version": "3.3.0-alpha",
   "description": "Generate typescript with ajv validation based on openapi schemas",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/GenerateOptions.ts
+++ b/src/GenerateOptions.ts
@@ -73,7 +73,7 @@ export interface GenerateOptions {
   skipDecoders?: boolean;
 
   /**
-   * use in combination with validator output module to add .js extension to imports of generated files
+   * when this option is enabled, standaloneOptions.validatorOutput is automatically set to "module"
    */
   esm?: boolean;
 }

--- a/src/GenerateOptions.ts
+++ b/src/GenerateOptions.ts
@@ -71,4 +71,9 @@ export interface GenerateOptions {
    * don't output decoder files
    */
   skipDecoders?: boolean;
+
+  /**
+   * use in combination with validator output module to add .js extension to imports of generated files
+   */
+  esm?: boolean;
 }

--- a/src/generate.ts
+++ b/src/generate.ts
@@ -56,6 +56,7 @@ export async function generate(options: GenerateOptions) {
         options.addFormats ?? false,
         options.formatOptions,
         options.standalone.validatorOutput,
+        options.esm ?? false,
         directories,
         prettierOptions
       );
@@ -66,6 +67,7 @@ export async function generate(options: GenerateOptions) {
         options.addFormats ?? false,
         options.formatOptions,
         options.standalone.validatorOutput,
+        options.esm ?? false,
         directories,
         prettierOptions
       );
@@ -81,7 +83,7 @@ export async function generate(options: GenerateOptions) {
   generateHelpers(prettierOptions, directories);
 
   if (options.skipMetaFile !== true) {
-    generateMetaFile(allDefinitions, directories, prettierOptions);
+    generateMetaFile(allDefinitions, directories, prettierOptions, options.esm ?? false);
   }
 
   console.info(`Successfully generated files for ${schemaFile}`);

--- a/src/generate.ts
+++ b/src/generate.ts
@@ -55,7 +55,7 @@ export async function generate(options: GenerateOptions) {
         schema,
         options.addFormats ?? false,
         options.formatOptions,
-        options.standalone.validatorOutput,
+        options.esm ? "module" : options.standalone.validatorOutput,
         options.esm ?? false,
         directories,
         prettierOptions
@@ -66,7 +66,7 @@ export async function generate(options: GenerateOptions) {
         schema,
         options.addFormats ?? false,
         options.formatOptions,
-        options.standalone.validatorOutput,
+        options.esm ? "module" : options.standalone.validatorOutput,
         options.esm ?? false,
         directories,
         prettierOptions

--- a/src/generate/generate-meta.ts
+++ b/src/generate/generate-meta.ts
@@ -1,11 +1,13 @@
 import { format, Options } from "prettier";
 import { mkdirSync, writeFileSync } from "fs";
 import path from "path";
+import { ValidatorOutput } from "../GenerateOptions";
 
 export function generateMetaFile(
   definitionNames: string[],
   outDirs: string[],
-  prettierOptions: Options
+  prettierOptions: Options,
+  esm: boolean
 ): void {
   const metas = definitionNames
     .map((definitionName) => {
@@ -13,7 +15,7 @@ export function generateMetaFile(
     })
     .join("\n");
 
-  const rawOutput = metaTemplate
+  const rawOutput = metaTemplate(esm)
     .replace(/\$Definitions/g, metas)
     .replace(/\$ModelImports/g, definitionNames.join(", "))
 
@@ -25,9 +27,11 @@ export function generateMetaFile(
   });
 }
 
-const metaTemplate = `
+const metaTemplate = (esm: boolean) => {
+  const importExtension = esm ? ".js" : "";
+  return `
 /* eslint-disable */
-import { $ModelImports } from './models';
+import { $ModelImports } from './models${importExtension}';
 
 export const schemaDefinitions = {
   $Definitions
@@ -41,4 +45,5 @@ export interface SchemaInfo<T> {
 function info<T>(definitionName: string, schemaRef: string): SchemaInfo<T> {
   return { definitionName, schemaRef };
 }
-`;
+`
+}


### PR DESCRIPTION
Adds an `esm` option. This option tells the lib that all the import paths of the generated files contain javascript extensions.