### PR TITLE
Add formats before ajv.compile

### DIFF
--- a/src/generate/generate-compile-decoders.ts
+++ b/src/generate/generate-compile-decoders.ts
@@ -55,9 +55,9 @@ import { validateJson } from './validate';
 import { $ModelImports } from './models';
 import jsonSchema from './schema.json';
 
-const ajv = new Ajv({ strict: false });
-ajv.compile(jsonSchema);
+export const ajv = new Ajv({ strict: false });
 $Formats
+ajv.compile(jsonSchema);
 
 // Decoders
 $Decoders


### PR DESCRIPTION
Minor changes to the decoder generator template:
- moved adding the ajv-formats before compiling the schema to avoid `unknown format` warnings
- exported the ajv object so the initialized schema can be used elsewhere