### PR TITLE
Feature: option for additional properties

### DIFF
--- a/src/builder.ts
+++ b/src/builder.ts
@@ -20,7 +20,7 @@ type PropertyBaseOptions = Pick<
 
 type ObjectBaseOptions = Pick<
   JSONSchema,
-  "title" | "description" | "default"
+  "title" | "description" | "default" | "additionalProperties"
 >;
 
 type ArrayOptions = PropertyBaseOptions;

--- a/tests/schemas/compose-schema.js
+++ b/tests/schemas/compose-schema.js
@@ -30,6 +30,11 @@ types.BarComponent = compose(
   })
 );
 
+types.BazComponent = object({
+  type: constant("baz"),
+  name: string(),
+}, {additionalProperties: string()})
+
 types.AnyComponent = anyOf(["BarComponent", "FooComponent"]);
 
 module.exports = { types };

--- a/tests/src/__snapshots__/compose-schema.test.ts.snap
+++ b/tests/src/__snapshots__/compose-schema.test.ts.snap
@@ -32,6 +32,11 @@ export interface BarComponent {
   type: \\"bar\\";
   name: string;
 }
+export interface BazComponent {
+  type: \\"baz\\";
+  name: string;
+  [k: string]: string;
+}
 "
 `;
 
@@ -97,6 +102,27 @@ exports[`compose-schema schema should match 1`] = `
         \\"name\\"
       ]
     },
+    \\"BazComponent\\": {
+      \\"type\\": \\"object\\",
+      \\"properties\\": {
+        \\"type\\": {
+          \\"type\\": \\"string\\",
+          \\"enum\\": [
+            \\"baz\\"
+          ]
+        },
+        \\"name\\": {
+          \\"type\\": \\"string\\"
+        }
+      },
+      \\"required\\": [
+        \\"type\\",
+        \\"name\\"
+      ],
+      \\"additionalProperties\\": {
+        \\"type\\": \\"string\\"
+      }
+    },
     \\"AnyComponent\\": {
       \\"anyOf\\": [
         {
@@ -117,6 +143,9 @@ exports[`compose-schema schema should match 1`] = `
     },
     \\"BarComponent\\": {
       \\"$ref\\": \\"#/definitions/BarComponent\\"
+    },
+    \\"BazComponent\\": {
+      \\"$ref\\": \\"#/definitions/BazComponent\\"
     },
     \\"AnyComponent\\": {
       \\"$ref\\": \\"#/definitions/AnyComponent\\"

--- a/tests/src/__snapshots__/simple-schema.test.ts.snap
+++ b/tests/src/__snapshots__/simple-schema.test.ts.snap
@@ -220,9 +220,8 @@ export function validateJson(
     return jsonObject;
   }
 
-  const jsonPreviewStr = (typeof json === \\"string\\"
-    ? json
-    : JSON.stringify(jsonObject)
+  const jsonPreviewStr = (
+    typeof json === \\"string\\" ? json : JSON.stringify(jsonObject)
   ).substring(0, 200);
   if (validator.errors) {
     throw Error(

--- a/tests/src/__snapshots__/simple-schema.test.ts.snap
+++ b/tests/src/__snapshots__/simple-schema.test.ts.snap
@@ -220,8 +220,9 @@ export function validateJson(
     return jsonObject;
   }
 
-  const jsonPreviewStr = (
-    typeof json === \\"string\\" ? json : JSON.stringify(jsonObject)
+  const jsonPreviewStr = (typeof json === \\"string\\"
+    ? json
+    : JSON.stringify(jsonObject)
   ).substring(0, 200);
   if (validator.errors) {
     throw Error(


### PR DESCRIPTION
# Problem
There is no option for additional properties on the outer component. Currently, the only option is to use the anonymousData() type. However this always results in:

`export interface BazComponent {
    type: "baz";
    name: string;
    additionalProps: {
        [k: string]: string;
    }
}`

# Solution
Add "additionalProperties" to the objectBaseOptions to create objects like:

`export interface BazComponent {
    type: "baz";
    name: string;
    [k: string]: string;
}`
